### PR TITLE
fix: coordinate calculation error when SVG is scaled

### DIFF
--- a/packages/react-bezier-spline-editor/src/react/BezierSplineEditor.tsx
+++ b/packages/react-bezier-spline-editor/src/react/BezierSplineEditor.tsx
@@ -67,8 +67,11 @@ export function BezierSplineEditor({
     event.preventDefault();
 
     const rect = svgRef.current.getBoundingClientRect();
-    let x = event.clientX - rect.left - padding;
-    let y = event.clientY - rect.top - padding;
+
+    const scale = rect.width / width
+
+    let x = (event.clientX - rect.left - padding) / scale;
+    let y = (event.clientY - rect.top - padding) / scale;
 
     // Constrain all points within the bounding box
     x = Math.max(0, Math.min(rect.width - padding * 2, x));
@@ -92,8 +95,11 @@ export function BezierSplineEditor({
   const handleAddPoint = (event: React.MouseEvent) => {
     if (!svgRef.current) return;
     const rect = svgRef.current.getBoundingClientRect();
-    const x = event.clientX - rect.left - padding;
-    const y = event.clientY - rect.top - padding;
+    
+    const scale = rect.width / width
+
+    let x = (event.clientX - rect.left - padding) / scale;
+    let y = (event.clientY - rect.top - padding) / scale;
 
     // Find the nearest existing anchor points
     // let nearestIndex = 0;


### PR DESCRIPTION
If the SVG is scaled, coordinate calculations will go wrong in the 'handleAddPoint' and 'handleDrag' events because the bounding client rect is not the same as the 'width' parameter input.

Fixed by taking the scale factor into calculation when calculating coordinates.